### PR TITLE
fixed results with 0 rows

### DIFF
--- a/tap_mysql/client.py
+++ b/tap_mysql/client.py
@@ -260,6 +260,8 @@ class MySQLConnector(SQLConnector):
                         )
                         custom_result = connection.execute(query)
                         custom_rec = custom_result.fetchone()
+                        if not custom_rec:
+                            continue
                         # inject the table_schema into the list of columns
                         custom_rec_keys = list(custom_rec._fields) + ["mysql_schema"]
 


### PR DESCRIPTION
There was a bug that resulted in an error when a query did not error but returned 0 rows. This skips those results.